### PR TITLE
remove arguments from component lifecycle hooks

### DIFF
--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -82,7 +82,7 @@ export default Ember.Mixin.create({
   },
 
   didRender() {
-    this._super(...arguments);
+    this._super();
     this.autoHideOnDisabled();
   },
 
@@ -98,7 +98,7 @@ export default Ember.Mixin.create({
   },
 
   willDestroyElement() {
-    this._super(...arguments);
+    this._super();
     this.get('pikaday').destroy();
   },
 


### PR DESCRIPTION
The usage of `arguments` in component lifecycle hooks is deprecated. This change removes the `ember-views.lifecycle-hook-arguments` deprecation warning and prevents consumers of this addon from having to forward the arguments to `ember-pikaday`.